### PR TITLE
Fixed problems with ruby-3.x

### DIFF
--- a/lib/housecanary/api/sales_history.rb
+++ b/lib/housecanary/api/sales_history.rb
@@ -11,7 +11,7 @@ module Housecanary
       extend Dry::Initializer
       option :api_code_description, optional: true
       option :api_code, optional: true
-      option :result, type: Dry::Types['coercible.array'].of(Dry.Types.Constructor(Sale))
+      option :result, type: Dry::Types['coercible.array'].of(Dry.Types.Constructor(Sale) { |args| Sale.new(**args) })
     end
   end
 end


### PR DESCRIPTION
We had problems with the previous ruby compatibility update. After creating `SalesHistory.new(**args)`, if we have a result field that is NOT empty, we get an error when initializing with the `Dry.Types.Constructor`